### PR TITLE
fix slug for blog post on EUM'26 day 3

### DIFF
--- a/docs/posts/2026/04/eum26-day3.md
+++ b/docs/posts/2026/04/eum26-day3.md
@@ -2,7 +2,7 @@
 authors:
   - boegel
 date: 2026-04-23
-slug: eum26
+slug: eum26-day3
 hide:
   - navigation
 ---


### PR DESCRIPTION
This will change URL https://blog.easybuild.io/2026/04/23/eum26 to https://blog.easybuild.io/2026/04/23/eum26-day3, so better do it know before the word spreads ;)